### PR TITLE
Fix QuakePlaneAxes' icon path

### DIFF
--- a/addons/qodot/src/nodes/quake_plane_axes.gd
+++ b/addons/qodot/src/nodes/quake_plane_axes.gd
@@ -1,4 +1,4 @@
-class_name QuakePlaneAxes, 'res://addons/Qodot/Icons/icon_qodot_spatial.svg'
+class_name QuakePlaneAxes, 'res://addons/qodot/icons/icon_qodot_spatial.svg'
 extends ImmediateGeometry
 tool
 

--- a/project.godot
+++ b/project.godot
@@ -99,7 +99,7 @@ _global_script_class_icons={
 "QuakeMapImportPlugin": "",
 "QuakeMapReader": "",
 "QuakePlane": "",
-"QuakePlaneAxes": "res://addons/Qodot/Icons/icon_qodot_spatial.svg"
+"QuakePlaneAxes": "res://addons/qodot/icons/icon_qodot_spatial.svg"
 }
 
 [application]


### PR DESCRIPTION
It contained an uppercase character, which means it didn't match the case of the actual path. This broke Qodot on case-sensitive filesystems.